### PR TITLE
remove debug statement resulting in not running all cases

### DIFF
--- a/commutativity/test.py
+++ b/commutativity/test.py
@@ -247,7 +247,7 @@ class CommutativityTestSuite(object):
         total = total * len(self.initials)
         
         print 'Running a total of {0} testcases.'.format(total)
-        debug_cases = [1] #[257] #[116] # TODO(jm): Debug code, remove
+        debug_cases = None #[1] #[257] #[116] # TODO(jm): Debug code, remove
         for i in self.initials:
             for a,b in valid_perms:
                 caseno += 1


### PR DESCRIPTION
I don't have write permissions on the nsg-ethz org.

This needs to be merged in, otherwise only 1 of 1360 testcases is run (I had left some debugging code in, sorry).
